### PR TITLE
xtfrm.data.frame(x) : cannot xtfrm data frames

### DIFF
--- a/R/sciClone.R
+++ b/R/sciClone.R
@@ -228,7 +228,9 @@ sciClone <- function(vafs, copyNumberCalls=NULL, regionsToExclude=NULL,
       vafs.1d.merged = merge(vafs.merged.orig,vafs.1d.merged.cn2, by.x=c(1:length(vafs.merged.orig)),
         by.y=c(1:length(vafs.merged.orig)),all.x=TRUE)
       ##sort by chr, st
-      vafs.1d.merged = vafs.1d.merged[order(vafs.1d.merged[,1,drop=FALSE], vafs.1d.merged[,2,drop=FALSE]),]
+      # vafs.1d.merged = vafs.1d.merged[order(vafs.1d.merged[,1,drop=FALSE], vafs.1d.merged[,2,drop=FALSE]),]
+      # hot fix using arrange from dplyr package (axel kunstner 2023-10-10)
+      vafs.1d.merged = vafs.1d.merged |> dplyr::arrange(chr, st)
       vafs.1d[[i]] = vafs.1d.merged
     }
   }

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ As of mid-2022, the NORMT3 package, which is a dependency of sciclone/bmm, has b
     
 Then proceed with the below instructions:
 
+I forked sciclone from the orginial repo to fix the 'Error in xtfrm.data.frame(x) : cannot xtfrm data frames' issue in the sciClone() function. Make sure dplyr is installed (e.g. install.packages('tidyverse') and R >= 4.1.0.
 
 Both the 'sciClone' package and it's 'bmm' dependency can be installed by doing the following:
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Both the 'sciClone' package and it's 'bmm' dependency can be installed by doing 
     install.packages("devtools")
     library(devtools)
     install_github("genome/bmm")
-    install_github("genome/sciClone")
+    #install_github("genome/sciClone")
+    # install sciClone with fix for 'Error in xtfrm.data.frame(x) : cannot xtfrm data frames'
+    install_github("kunstner/sciClone")
 
 If you prefer to build the package by hand, follow these steps:
 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ Both the 'sciClone' package and it's 'bmm' dependency can be installed by doing 
 If you prefer to build the package by hand, follow these steps:
 
 - Make sure that you have the dependencies from the CRAN and BioConductor repos:
-IRanges, rgl, RColorBrewer, ggplot2, grid, plotrix, methods, NORMT3, MKmisc, TeachingDemos
+IRanges, rgl, RColorBrewer, ggplot2, grid, plotrix, methods, NORMT3, MKmisc, TeachingDemos, dplyr
 
 - install the bmm package from [https://github.com/genome/bmm](https://github.com/genome/bmm)
 
 - Download and build from source:
 
-        git clone git@github.com:genome/sciclone.git
+        # git clone git@github.com:genome/sciclone.git
+        git clone git@github.com:kunstner/sciclone.git
         R CMD build sciclone
         R CMD INSTALL sciClone_1.1.0.tar.gz
 


### PR DESCRIPTION
Fix for Error in xtfrm.data.frame(x) : cannot xtfrm data frames in sciClone.R
