### PR TITLE
add a dockerfile to build the sciClone package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+# bioconductor 3.17
+FROM bioconductor/bioconductor_docker@sha256:258c0e8b9d0e001adbca7f07372833e3f3b4c0495aa728502c6a2bb241383b18
+
+RUN wget https://cran.r-project.org/src/contrib/Archive/NORMT3/NORMT3_1.0.4.tar.gz && \
+    R CMD INSTALL NORMT3_1.0.4.tar.gz
+
+RUN R --quiet -e "BiocManager::install(c('IRanges','MKmisc')); devtools::install_github('genome/bmm'); devtools::install_github('genome/sciClone')"
+
+USER rstudio

--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ IRanges, rgl, RColorBrewer, ggplot2, grid, plotrix, methods, NORMT3, MKmisc, Tea
         R CMD build sciclone
         R CMD INSTALL sciClone_1.1.0.tar.gz
 
+Alternatively, a Dockerfile is included and can be built using:
+
+```{bash}
+# change to sciclone repo
+docker build . -t sciclone
+```
+
+Once the image is built you can start an interactive R session using the container by running:
+
+```{bash}
+docker run -it --rm sciclone /usr/bin/env R
+```
+
 ## Usage
     library(sciClone)
 


### PR DESCRIPTION
Hi @chrisamiller ,

I'm doing a volunteer project with a PI and wanted to run sciClone on the dataset. I saw that you had install instructions, but thought it might be nice for future visitors if there was a docker image. I guess ideally someone like biocontainers could host it so users don't have to build it, but thought even having the Dockerfile would make it easier for people to use.

Let me know if you have any feedback on the change.

Best,
Sol